### PR TITLE
Fix error code handling for xlsx

### DIFF
--- a/freexl/conandata.yml
+++ b/freexl/conandata.yml
@@ -1,6 +1,6 @@
 sources:
   "2.0.99.cci.20260210":
-    url: "https://github.com/shun2wang/freexl_jasp/archive/e17b7806b80e3594c5d36f00e11bb91d7f5e1cf7.tar.gz"
+    url: "https://github.com/shun2wang/freexl_jasp/archive/8c8890ab4c8fafc9931d78059a0132f97ee4de30.tar.gz"
     sha256: "ddad6d47754b2d2a87b5ebe7ded457b5da17d31c57c48eb39be6de62c095a998"
   "2.0.99.cci.20250526":
     url: "https://github.com/jasp-stats/freexl/archive/92f31bba661129948c34b3941dd0bab28511fbb1.tar.gz"

--- a/freexl/conandata.yml
+++ b/freexl/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "2.0.99.cci.20260210":
     url: "https://github.com/shun2wang/freexl_jasp/archive/e17b7806b80e3594c5d36f00e11bb91d7f5e1cf7.tar.gz"
-    sha256: "e6ca9d36fbf09facd24e3bf896a86e1782ee95a1d150ed4b36d52047efaa4414"
+    sha256: "ddad6d47754b2d2a87b5ebe7ded457b5da17d31c57c48eb39be6de62c095a998"
   "2.0.99.cci.20250526":
     url: "https://github.com/jasp-stats/freexl/archive/92f31bba661129948c34b3941dd0bab28511fbb1.tar.gz"
     sha256: "baedf906e47122fc7f53dc77b12b628fd437ff83cc7a73acfbc985c2b9fc9120"

--- a/freexl/conandata.yml
+++ b/freexl/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.99.cci.20260210":
+    url: "https://github.com/shun2wang/freexl_jasp/archive/e17b7806b80e3594c5d36f00e11bb91d7f5e1cf7.tar.gz"
+    sha256: "e6ca9d36fbf09facd24e3bf896a86e1782ee95a1d150ed4b36d52047efaa4414"
   "2.0.99.cci.20250526":
     url: "https://github.com/jasp-stats/freexl/archive/92f31bba661129948c34b3941dd0bab28511fbb1.tar.gz"
     sha256: "baedf906e47122fc7f53dc77b12b628fd437ff83cc7a73acfbc985c2b9fc9120"
@@ -6,6 +9,8 @@ sources:
     url: "http://www.gaia-gis.it/gaia-sins/freexl-sources/freexl-2.0.0.tar.gz"
     sha256: "176705f1de58ab7c1eebbf5c6de46ab76fcd8b856508dbd28f5648f7c6e1a7f0"
 patches:
+  "2.0.99.cci.20260210":
+    - patch_file: "patches/fix-nmake-2.0.0.patch"
   "2.0.99.cci.20250526":
     - patch_file: "patches/fix-nmake-2.0.0.patch"
   "2.0.0":

--- a/freexl/conandata.yml
+++ b/freexl/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "2.0.99.cci.20260210":
     url: "https://github.com/shun2wang/freexl_jasp/archive/8c8890ab4c8fafc9931d78059a0132f97ee4de30.tar.gz"
-    sha256: "ddad6d47754b2d2a87b5ebe7ded457b5da17d31c57c48eb39be6de62c095a998"
+    sha256: "5fc4059c3622c5a25f201d1dcffe79938cd58d3afe33dbb583a684d4a3e8747f"
   "2.0.99.cci.20250526":
     url: "https://github.com/jasp-stats/freexl/archive/92f31bba661129948c34b3941dd0bab28511fbb1.tar.gz"
     sha256: "baedf906e47122fc7f53dc77b12b628fd437ff83cc7a73acfbc985c2b9fc9120"


### PR DESCRIPTION
For reviewers: You shoud update the url (to JASP's repo) and sha256 after merge https://github.com/jasp-stats/freexl/pull/2

Then I will update JASP-desktop cmake.